### PR TITLE
feat!: Give the adress of incident to PreCheck methods for plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ import (
 type LogNotifier struct {
 }
 
-func (n LogNotifier) PreCheck(incident models.Incident) error {
+func (n LogNotifier) PreCheck(incident *models.Incident) error {
 	return nil
 }
 

--- a/common/helper.go
+++ b/common/helper.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type HeaderTransport struct {

--- a/config/types.go
+++ b/config/types.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type ForComponent struct {

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -5,7 +5,7 @@ package emitter
 import (
 	"github.com/olebedev/emitter"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type emitterInterface interface {

--- a/extemplate/funcs.go
+++ b/extemplate/funcs.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/dustin/go-humanize"
 
-	"github.com/orange-cloudfoundry/statusetat/locations"
-	"github.com/orange-cloudfoundry/statusetat/markdown"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/locations"
+	"github.com/orange-cloudfoundry/statusetat/v2/markdown"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 func iconState(state models.ComponentState) string {

--- a/extemplate/template.go
+++ b/extemplate/template.go
@@ -16,9 +16,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/markdown"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/markdown"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 var extendsRegex *regexp.Regexp

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/orange-cloudfoundry/statusetat
+module github.com/orange-cloudfoundry/statusetat/v2
 
 go 1.24.1
 

--- a/main.go
+++ b/main.go
@@ -17,16 +17,16 @@ import (
 	"github.com/rs/cors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/locations"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
-	_ "github.com/orange-cloudfoundry/statusetat/notifiers/email"
-	_ "github.com/orange-cloudfoundry/statusetat/notifiers/grafana"
-	_ "github.com/orange-cloudfoundry/statusetat/notifiers/log"
-	_ "github.com/orange-cloudfoundry/statusetat/notifiers/plugin"
-	_ "github.com/orange-cloudfoundry/statusetat/notifiers/slack"
-	"github.com/orange-cloudfoundry/statusetat/serves"
-	"github.com/orange-cloudfoundry/statusetat/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/locations"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
+	_ "github.com/orange-cloudfoundry/statusetat/v2/notifiers/email"
+	_ "github.com/orange-cloudfoundry/statusetat/v2/notifiers/grafana"
+	_ "github.com/orange-cloudfoundry/statusetat/v2/notifiers/log"
+	_ "github.com/orange-cloudfoundry/statusetat/v2/notifiers/plugin"
+	_ "github.com/orange-cloudfoundry/statusetat/v2/notifiers/slack"
+	"github.com/orange-cloudfoundry/statusetat/v2/serves"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
 )
 
 var (

--- a/notifiers/email/email.go
+++ b/notifiers/email/email.go
@@ -12,10 +12,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/gomail.v2"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/extemplate"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/extemplate"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 )
 
 func init() {

--- a/notifiers/email/email_test.go
+++ b/notifiers/email/email_test.go
@@ -8,11 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/gomail.v2"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
-	"github.com/orange-cloudfoundry/statusetat/notifiers/email"
-	"github.com/orange-cloudfoundry/statusetat/notifiers/email/emailfakes"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/email"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/email/emailfakes"
 )
 
 var _ = Describe("Email", func() {

--- a/notifiers/email/emailfakes/fake_email_dialer.go
+++ b/notifiers/email/emailfakes/fake_email_dialer.go
@@ -4,7 +4,7 @@ package emailfakes
 import (
 	"sync"
 
-	"github.com/orange-cloudfoundry/statusetat/notifiers/email"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/email"
 	gomail "gopkg.in/gomail.v2"
 )
 

--- a/notifiers/grafana/grafana_annotation.go
+++ b/notifiers/grafana/grafana_annotation.go
@@ -16,7 +16,7 @@ import (
 	"github.com/orange-cloudfoundry/statusetat/v2/config"
 	"github.com/orange-cloudfoundry/statusetat/v2/models"
 	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
-	"github.com/orange-cloudfoundry/statusetat/utils"
+	"github.com/orange-cloudfoundry/statusetat/v2/utils"
 )
 
 func init() {

--- a/notifiers/grafana/grafana_annotation.go
+++ b/notifiers/grafana/grafana_annotation.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 	"github.com/orange-cloudfoundry/statusetat/utils"
 )
 

--- a/notifiers/interface.go
+++ b/notifiers/interface.go
@@ -20,7 +20,7 @@ type NotifierMetadataField interface {
 }
 
 type NotifierPreCheck interface {
-	PreCheck(incident models.Incident) error
+	PreCheck(incident *models.Incident) error
 }
 
 // special interface for creating a moke

--- a/notifiers/interface.go
+++ b/notifiers/interface.go
@@ -3,8 +3,8 @@ package notifiers
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . NotifierAllInOne
 
 import (
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type Notifier interface {

--- a/notifiers/log/log.go
+++ b/notifiers/log/log.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 )
 
 func init() {

--- a/notifiers/manager.go
+++ b/notifiers/manager.go
@@ -5,10 +5,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/emitter"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/emitter"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
 )
 
 type ToNotifie struct {

--- a/notifiers/notifiersfakes/fake_notifier_all_in_one.go
+++ b/notifiers/notifiersfakes/fake_notifier_all_in_one.go
@@ -4,9 +4,9 @@ package notifiersfakes
 import (
 	"sync"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 )
 
 type FakeNotifierAllInOne struct {
@@ -422,16 +422,16 @@ func (fake *FakeNotifierAllInOne) NotifyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeNotifierAllInOne) PreCheck(arg1 models.Incident) error {
+func (fake *FakeNotifierAllInOne) PreCheck(arg1 *models.Incident) error {
 	fake.preCheckMutex.Lock()
 	ret, specificReturn := fake.preCheckReturnsOnCall[len(fake.preCheckArgsForCall)]
 	fake.preCheckArgsForCall = append(fake.preCheckArgsForCall, struct {
 		arg1 models.Incident
-	}{arg1})
+	}{*arg1})
 	fake.recordInvocation("PreCheck", []interface{}{arg1})
 	fake.preCheckMutex.Unlock()
 	if fake.PreCheckStub != nil {
-		return fake.PreCheckStub(arg1)
+		return fake.PreCheckStub(*arg1)
 	}
 	if specificReturn {
 		return ret.result1

--- a/notifiers/plugin/client.go
+++ b/notifiers/plugin/client.go
@@ -7,10 +7,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers/plugin/proto"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/plugin/proto"
 )
 
 type GRPCClient struct {
@@ -99,9 +99,9 @@ func (m *GRPCClient) MetadataFields() ([]models.MetadataField, error) {
 
 }
 
-func (m *GRPCClient) PreCheck(incident models.Incident) error {
+func (m *GRPCClient) PreCheck(incident *models.Incident) error {
 	resp, err := m.client.PreCheck(context.Background(), &proto.NotifyRequest{
-		Incident: IncidentToProto(incident),
+		Incident: IncidentToProto(*incident),
 	})
 	if err != nil {
 		return err

--- a/notifiers/plugin/convert.go
+++ b/notifiers/plugin/convert.go
@@ -7,9 +7,9 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers/plugin/proto"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/plugin/proto"
 )
 
 func IncidentToProto(incident models.Incident) *proto.Incident {

--- a/notifiers/plugin/interface.go
+++ b/notifiers/plugin/interface.go
@@ -31,7 +31,7 @@ type Notifier interface {
 	Id() (string, error)
 	MetadataFields() ([]models.MetadataField, error)
 	Notify(notifyReq *models.NotifyRequest) error
-	PreCheck(incident models.Incident) error
+	PreCheck(incident *models.Incident) error
 }
 
 type NotifierGRPCPlugin struct {

--- a/notifiers/plugin/interface.go
+++ b/notifiers/plugin/interface.go
@@ -6,9 +6,9 @@ import (
 	pluginhc "github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers/plugin/proto"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/plugin/proto"
 )
 
 // Handshake is a common handshake that is shared by plugin and host.

--- a/notifiers/plugin/plugin.go
+++ b/notifiers/plugin/plugin.go
@@ -126,6 +126,6 @@ func (n *Plugin) MetadataFields() []models.MetadataField {
 	return fields
 }
 
-func (n *Plugin) PreCheck(incident models.Incident) error {
+func (n *Plugin) PreCheck(incident *models.Incident) error {
 	return n.notifier.PreCheck(incident)
 }

--- a/notifiers/plugin/plugin.go
+++ b/notifiers/plugin/plugin.go
@@ -7,10 +7,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 )
 
 func init() {

--- a/notifiers/plugin/server.go
+++ b/notifiers/plugin/server.go
@@ -7,9 +7,9 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers/plugin/proto"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/plugin/proto"
 )
 
 type GRPCServer struct {

--- a/notifiers/plugin/server.go
+++ b/notifiers/plugin/server.go
@@ -116,7 +116,8 @@ func (s *GRPCServer) MetadataFields(ctx context.Context, request *emptypb.Empty)
 }
 
 func (s *GRPCServer) PreCheck(ctx context.Context, request *proto.NotifyRequest) (*proto.ErrorResponse, error) {
-	err := s.Impl.PreCheck(ProtoToIncident(request.Incident))
+	protoToIncident := ProtoToIncident(request.Incident)
+	err := s.Impl.PreCheck(&protoToIncident)
 	if err != nil {
 		return &proto.ErrorResponse{
 			Error: &proto.Error{

--- a/notifiers/slack/slack.go
+++ b/notifiers/slack/slack.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 	"github.com/orange-cloudfoundry/statusetat/utils"
 )
 

--- a/notifiers/slack/slack.go
+++ b/notifiers/slack/slack.go
@@ -15,7 +15,7 @@ import (
 	"github.com/orange-cloudfoundry/statusetat/v2/config"
 	"github.com/orange-cloudfoundry/statusetat/v2/models"
 	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
-	"github.com/orange-cloudfoundry/statusetat/utils"
+	"github.com/orange-cloudfoundry/statusetat/v2/utils"
 )
 
 func init() {

--- a/notifiers/slack/slack_test.go
+++ b/notifiers/slack/slack_test.go
@@ -10,11 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 
-	"github.com/orange-cloudfoundry/statusetat/notifiers/slack"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers/slack"
 )
 
 var _ = Describe("Slack", func() {

--- a/serves/admin.go
+++ b/serves/admin.go
@@ -6,11 +6,11 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 	"github.com/prometheus/common/version"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type menuItem struct {

--- a/serves/admin_test.go
+++ b/serves/admin_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 var _ = Describe("Admin", func() {

--- a/serves/api.go
+++ b/serves/api.go
@@ -13,10 +13,10 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/nicklaw5/go-respond"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/emitter"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/notifiers"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/emitter"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/notifiers"
 )
 
 func (a *Serve) CreateIncident(w http.ResponseWriter, req *http.Request) {

--- a/serves/api.go
+++ b/serves/api.go
@@ -80,7 +80,7 @@ func (a *Serve) CreateIncident(w http.ResponseWriter, req *http.Request) {
 	incident.GUID = guid
 	incident.Messages = a.messagesGuid(guid, incident.Messages, loc)
 
-	err = a.runPreCheck(incident)
+	err = a.runPreCheck(&incident)
 	if err != nil {
 		JSONError(w, err, http.StatusPreconditionFailed)
 		return
@@ -260,7 +260,7 @@ func (a *Serve) Update(w http.ResponseWriter, req *http.Request) {
 
 	incident.UpdatedAt = time.Now()
 
-	err = a.runPreCheck(incident)
+	err = a.runPreCheck(&incident)
 	if err != nil {
 		JSONError(w, err, http.StatusPreconditionFailed)
 		return
@@ -282,7 +282,7 @@ func (a *Serve) Update(w http.ResponseWriter, req *http.Request) {
 	respond.NewResponse(w).Ok(incident)
 }
 
-func (a *Serve) runPreCheck(incident models.Incident) error {
+func (a *Serve) runPreCheck(incident *models.Incident) error {
 	var result error
 	for _, preChecker := range notifiers.PreCheckers(*incident.Components) {
 		err := preChecker.PreCheck(incident)

--- a/serves/api_test.go
+++ b/serves/api_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/serves"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/serves"
 )
 
 var _ = Describe("Api", func() {

--- a/serves/cal.go
+++ b/serves/cal.go
@@ -6,7 +6,7 @@ import (
 
 	ics "github.com/arran4/golang-ical"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 func (a *Serve) Ical(w http.ResponseWriter, req *http.Request) {

--- a/serves/cal_test.go
+++ b/serves/cal_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 var _ = Describe("Cal", func() {

--- a/serves/common.go
+++ b/serves/common.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 func (a *Serve) scheduled(from, to time.Time) ([]models.Incident, error) {

--- a/serves/index.go
+++ b/serves/index.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type IndexData struct {

--- a/serves/init.go
+++ b/serves/init.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/goji/httpauth"
 	"github.com/gorilla/mux"
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/extemplate"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/extemplate"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
 )
 
 type HtmlTemplater interface {

--- a/serves/location.go
+++ b/serves/location.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gorilla/sessions"
-	"github.com/orange-cloudfoundry/statusetat/locations"
+	"github.com/orange-cloudfoundry/statusetat/v2/locations"
 )
 
 const (

--- a/serves/markdown.go
+++ b/serves/markdown.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/orange-cloudfoundry/statusetat/markdown"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/markdown"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 func (a *Serve) convertMessageToHtml(messages []models.Message) []models.Message {

--- a/serves/rss_test.go
+++ b/serves/rss_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 var _ = Describe("Rss", func() {

--- a/serves/serves_suite_test.go
+++ b/serves/serves_suite_test.go
@@ -16,14 +16,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-cloudfoundry/statusetat/config"
-	"github.com/orange-cloudfoundry/statusetat/emitter"
-	"github.com/orange-cloudfoundry/statusetat/emitter/emitterfakes"
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/serves"
-	"github.com/orange-cloudfoundry/statusetat/serves/servesfakes"
-	"github.com/orange-cloudfoundry/statusetat/storages"
-	"github.com/orange-cloudfoundry/statusetat/storages/storagesfakes"
+	"github.com/orange-cloudfoundry/statusetat/v2/config"
+	"github.com/orange-cloudfoundry/statusetat/v2/emitter"
+	"github.com/orange-cloudfoundry/statusetat/v2/emitter/emitterfakes"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/serves"
+	"github.com/orange-cloudfoundry/statusetat/v2/serves/servesfakes"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages/storagesfakes"
 )
 
 var router *mux.Router

--- a/serves/servesfakes/fake_html_templater.go
+++ b/serves/servesfakes/fake_html_templater.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/orange-cloudfoundry/statusetat/serves"
+	"github.com/orange-cloudfoundry/statusetat/v2/serves"
 )
 
 type FakeHtmlTemplater struct {

--- a/storages/db.go
+++ b/storages/db.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 func init() {

--- a/storages/db_test.go
+++ b/storages/db_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
 )
 
 var _ = Describe("Db", func() {

--- a/storages/local.go
+++ b/storages/local.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type Local struct {

--- a/storages/local_test.go
+++ b/storages/local_test.go
@@ -10,8 +10,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
 	"github.com/orange-cloudfoundry/statusetat/utils"
 )
 

--- a/storages/local_test.go
+++ b/storages/local_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/orange-cloudfoundry/statusetat/v2/models"
 	"github.com/orange-cloudfoundry/statusetat/v2/storages"
-	"github.com/orange-cloudfoundry/statusetat/utils"
+	"github.com/orange-cloudfoundry/statusetat/v2/utils"
 )
 
 var _ = Describe("Local", func() {

--- a/storages/replicate.go
+++ b/storages/replicate.go
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 const (

--- a/storages/replicate_test.go
+++ b/storages/replicate_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/storages"
-	"github.com/orange-cloudfoundry/statusetat/storages/storagesfakes"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages/storagesfakes"
 )
 
 var _ = Describe("Replicate", func() {

--- a/storages/retry.go
+++ b/storages/retry.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type Retry struct {

--- a/storages/retry_test.go
+++ b/storages/retry_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/storages"
-	"github.com/orange-cloudfoundry/statusetat/storages/storagesfakes"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages/storagesfakes"
 )
 
 var _ = Describe("Retry", func() {

--- a/storages/s3.go
+++ b/storages/s3.go
@@ -15,9 +15,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/orange-cloudfoundry/statusetat/utils"
 	"github.com/orange-cloudfoundry/statusetat/v2/common"
 	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/utils"
 )
 
 type s3Session struct {

--- a/storages/s3.go
+++ b/storages/s3.go
@@ -15,9 +15,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/orange-cloudfoundry/statusetat/common"
-	"github.com/orange-cloudfoundry/statusetat/models"
 	"github.com/orange-cloudfoundry/statusetat/utils"
+	"github.com/orange-cloudfoundry/statusetat/v2/common"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type s3Session struct {

--- a/storages/storage.go
+++ b/storages/storage.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
 )
 
 type Store interface {

--- a/storages/storagesfakes/fake_store.go
+++ b/storages/storagesfakes/fake_store.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/orange-cloudfoundry/statusetat/models"
-	"github.com/orange-cloudfoundry/statusetat/storages"
+	"github.com/orange-cloudfoundry/statusetat/v2/models"
+	"github.com/orange-cloudfoundry/statusetat/v2/storages"
 )
 
 type FakeStore struct {


### PR DESCRIPTION
It's better to give the adress of the incident variable, that way, if the plugin needs to add metadatas in the structure, it'll be saved with a minimal code change

BREAKING CHANGE