### PR TITLE
PROPOSITION : feat!: adding notification via plugin for delete endpoint

### DIFF
--- a/models/flags.go
+++ b/models/flags.go
@@ -17,6 +17,7 @@ const (
 	Resolved
 	Monitoring
 	Idle
+	Cancelled
 )
 
 var AllIncidentState = []IncidentState{Unresolved, Monitoring, Resolved}

--- a/serves/api.go
+++ b/serves/api.go
@@ -343,6 +343,9 @@ func (a *Serve) Delete(w http.ResponseWriter, req *http.Request) {
 		JSONError(w, err, http.StatusPreconditionFailed)
 		return
 	}
+
+	emitter.Emit(models.NewNotifyRequest(incident, true))
+
 	w.WriteHeader(200)
 }
 

--- a/serves/api_test.go
+++ b/serves/api_test.go
@@ -282,6 +282,7 @@ var _ = Describe("Api", func() {
 
 			rr := CallRequest(NewRequestIntAdmin(http.MethodDelete, "/v1/incidents/1", nil))
 			Expect(rr.CheckError()).ToNot(HaveOccurred())
+			Expect(fakeEmitter.EmitCallCount()).To(Equal(1))
 
 			_, err = fakeStoreMem.Read("1")
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Goal is to be able for associated plugins to be able to cancel easily the opened maintainance on the associated application.

Notification is done after the delete in database, that way if an error arise during the DB deletion, no notification is sent to the plugins.
Added a new status "Cancelled" to properly manifest the new possibility