### PR TITLE
fix: updating order of deletion of an incident.

### DIFF
--- a/serves/api.go
+++ b/serves/api.go
@@ -325,6 +325,15 @@ func (a *Serve) Delete(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Using a "cancelled" state
+	incident.State = models.Cancelled
+
+	err = a.runPreCheck(&incident)
+	if err != nil {
+		JSONError(w, err, http.StatusPreconditionFailed)
+		return
+	}
+
 	err = a.store.Delete(guid)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -332,15 +341,6 @@ func (a *Serve) Delete(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		JSONError(w, err, http.StatusInternalServerError)
-		return
-	}
-
-	// Using a "cancelled" state
-	incident.State = models.Cancelled
-
-	err = a.runPreCheck(&incident)
-	if err != nil {
-		JSONError(w, err, http.StatusPreconditionFailed)
 		return
 	}
 


### PR DESCRIPTION
it's better to delete in statusetat only after we have been able to delete on the external provider, otherwise it would be harder to delete on the external provider.